### PR TITLE
Match with `translate` and `t`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Usage
 
-In Cerebro, type `translate en pt phrase` and the translation will be shown in the result below. You can specify a source and target language respectively. If you pass only the target, the source will be set to _auto_, if you don't specify any language, the source will be set to _auto_, and target to _en_.
+In Cerebro, type `translate en pt phrase` or `t en pt phrase` and the translation will be shown in the result below. You can specify a source and target language respectively. If you pass only the target, the source will be set to _auto_, if you don't specify any language, the source will be set to _auto_, and target to _en_.
 
 To see available languages type `translate l` or `translate languages`.
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -4,7 +4,7 @@ const parse = (term) => {
   const words = term.split(' ')
   const [keyword, first, second] = words
 
-  const match = keyword === KEYWORD || keyword === `${KEYWORD} `
+  const match = matchKeyword(keyword)
   const firstLang = getLang(first)
   const secondLang = getLang(second)
 
@@ -32,6 +32,15 @@ const parse = (term) => {
     match,
     query: match ? words.slice(1).join(' ') : '',
   }
+}
+
+const matchKeyword = (keyword) => {
+  const firstLetter = KEYWORD.charAt(0)
+
+  return keyword === KEYWORD
+    || keyword === `${KEYWORD} `
+    || keyword === firstLetter
+    || keyword === `${firstLetter} `
 }
 
 export default parse

--- a/src/parse.test.js
+++ b/src/parse.test.js
@@ -18,6 +18,18 @@ describe('parse', () => {
     expect(parse(term)).toEqual(expected)
   })
 
+  it('should match with the frist letter of the keyword', () => {
+    const term = 't en pt some text'
+    const expected = {
+      match: true,
+      query: 'some text',
+      source: { code: 'en', name: 'English' },
+      target: { code: 'pt', name: 'Portuguese' },
+    }
+
+    expect(parse(term)).toEqual(expected)
+  })
+
   it('should match with target language', () => {
     const term = 'translate pt some text'
     const expected = {


### PR DESCRIPTION
Closes #5.